### PR TITLE
Adjust ImplementationCreator for generics

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>com.github.peckb1</groupId>
         <artifactId>autojackson</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>autojackson-examples</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <build>
         <plugins>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.github.peckb1</groupId>
             <artifactId>autojackson-processor</artifactId>
-            <version>1.0.0</version>
+            <version>1.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/examples/resources/auto_model.json
+++ b/examples/resources/auto_model.json
@@ -14,7 +14,7 @@
       "occupation": "fire truck siren",
       "fires" : 15,
       "muppeteer" : {
-        "name" : "Steve Whitemire"
+        "name" : "Steve Whitmire"
       }
     },
     "muppeteer" : {

--- a/examples/resources/auto_model.json
+++ b/examples/resources/auto_model.json
@@ -12,7 +12,17 @@
       "name": "WEMBLEY",
       "age": 9,
       "occupation": "fire truck siren",
-      "fires" : 15
+      "fires" : 15,
+      "muppeteer" : {
+        "name" : "Steve Whitemire"
+      }
+    },
+    "muppeteer" : {
+      "name" : "Jerry Nelson"
+    },
+    "x" : 4,
+    "zed" : {
+      "abc" : 123
     }
   },
   "gorg": {
@@ -32,13 +42,19 @@
       "name": "MOKEY",
       "age": 11,
       "occupation": "radish picker",
-      "radishes" : 500
+      "radishes" : 500,
+      "muppeteer" : {
+        "name" : "Kathryn Mullen"
+      }
     },
     {
       "name": "BOOBER",
       "age": 11,
       "occupation": "clothes washer",
-      "superstitions" : 9001
+      "superstitions" : 9001,
+      "muppeteer" : {
+        "name" : "Dave Goelz"
+      }
     }
   ],
   "fraggleArray": [
@@ -46,13 +62,19 @@
       "name": "BOOBER",
       "age": 11,
       "occupation": "clothes washer",
-      "superstitions" : 9001
+      "superstitions" : 9001,
+      "muppeteer" : {
+        "name" : "Dave Goelz"
+      }
     },
     {
       "name": "MOKEY",
       "age": 11,
       "occupation": "radish picker",
-      "radishes" : 500
+      "radishes" : 500,
+      "muppeteer" : {
+        "name" : "Kathryn Mullen"
+      }
     }
   ],
   "gorgList": [

--- a/examples/src/main/java/com/github/peckb1/examples/auto/Fraggle.java
+++ b/examples/src/main/java/com/github/peckb1/examples/auto/Fraggle.java
@@ -13,12 +13,13 @@ import com.github.peckb1.processor.Named;
 import java.util.Optional;
 
 @AutoJackson(type = @AutoJackson.Type(FraggleName.class))
-public interface Fraggle {
+public interface Fraggle<M extends Muppeteer> {
 
     FraggleName getName();
     Integer getAge();
     @Named("occupation") String getJob();
     Optional<Fraggle> getRoommate();
+    M getMuppeteer();
 
     enum FraggleName {
         GOBO(Gobo.class),

--- a/examples/src/main/java/com/github/peckb1/examples/auto/Muppeteer.java
+++ b/examples/src/main/java/com/github/peckb1/examples/auto/Muppeteer.java
@@ -1,0 +1,8 @@
+package com.github.peckb1.examples.auto;
+
+import com.github.peckb1.processor.AutoJackson;
+
+@AutoJackson
+public interface Muppeteer {
+    String getName();
+}

--- a/examples/src/main/java/com/github/peckb1/examples/auto/fraggles/Boober.java
+++ b/examples/src/main/java/com/github/peckb1/examples/auto/fraggles/Boober.java
@@ -1,11 +1,12 @@
 package com.github.peckb1.examples.auto.fraggles;
 
 import com.github.peckb1.examples.auto.Fraggle;
+import com.github.peckb1.examples.auto.muppeteers.DaveGoelz;
 import com.github.peckb1.processor.AutoJackson;
 import com.github.peckb1.processor.Named;
 
 @AutoJackson
-public interface Boober extends Fraggle {
+public interface Boober extends Fraggle<DaveGoelz> {
 
     @Named("superstitions") long getNumberOfSuperstitions();
 

--- a/examples/src/main/java/com/github/peckb1/examples/auto/fraggles/Gobo.java
+++ b/examples/src/main/java/com/github/peckb1/examples/auto/fraggles/Gobo.java
@@ -1,12 +1,19 @@
 package com.github.peckb1.examples.auto.fraggles;
 
 import com.github.peckb1.examples.auto.Fraggle;
+import com.github.peckb1.examples.auto.muppeteers.JerryNelson;
 import com.github.peckb1.processor.AutoJackson;
 import com.github.peckb1.processor.Named;
 
+import java.io.IOException;
+import java.util.Map;
+
 @AutoJackson
-public interface Gobo extends Fraggle {
+public interface Gobo<X extends Number> extends Fraggle<JerryNelson> {
 
     @Named("postcards") int getFetchedPostcards();
 
+    X getX();
+
+    @Named("zed") Map getMap() throws IOException;
 }

--- a/examples/src/main/java/com/github/peckb1/examples/auto/fraggles/Mokey.java
+++ b/examples/src/main/java/com/github/peckb1/examples/auto/fraggles/Mokey.java
@@ -1,11 +1,12 @@
 package com.github.peckb1.examples.auto.fraggles;
 
 import com.github.peckb1.examples.auto.Fraggle;
+import com.github.peckb1.examples.auto.muppeteers.KathrynMullen;
 import com.github.peckb1.processor.AutoJackson;
 import com.github.peckb1.processor.Named;
 
 @AutoJackson
-public interface Mokey extends Fraggle {
+public interface Mokey extends Fraggle<KathrynMullen> {
 
     @Named("radishes") int getRadishesPicked();
 

--- a/examples/src/main/java/com/github/peckb1/examples/auto/fraggles/Mokey.java
+++ b/examples/src/main/java/com/github/peckb1/examples/auto/fraggles/Mokey.java
@@ -6,7 +6,7 @@ import com.github.peckb1.processor.AutoJackson;
 import com.github.peckb1.processor.Named;
 
 @AutoJackson
-public interface Mokey extends Fraggle<KathrynMullen> {
+public interface Mokey extends Fraggle {
 
     @Named("radishes") int getRadishesPicked();
 

--- a/examples/src/main/java/com/github/peckb1/examples/auto/fraggles/Red.java
+++ b/examples/src/main/java/com/github/peckb1/examples/auto/fraggles/Red.java
@@ -6,7 +6,5 @@ import com.github.peckb1.processor.Named;
 
 @AutoJackson
 public interface Red extends Fraggle {
-
     @Named("dives") int getDives();
-
 }

--- a/examples/src/main/java/com/github/peckb1/examples/auto/fraggles/Red.java
+++ b/examples/src/main/java/com/github/peckb1/examples/auto/fraggles/Red.java
@@ -1,10 +1,11 @@
 package com.github.peckb1.examples.auto.fraggles;
 
 import com.github.peckb1.examples.auto.Fraggle;
+import com.github.peckb1.examples.auto.muppeteers.KarenPrell;
 import com.github.peckb1.processor.AutoJackson;
 import com.github.peckb1.processor.Named;
 
 @AutoJackson
-public interface Red extends Fraggle {
+public interface Red extends Fraggle<KarenPrell> {
     @Named("dives") int getDives();
 }

--- a/examples/src/main/java/com/github/peckb1/examples/auto/fraggles/Red.java
+++ b/examples/src/main/java/com/github/peckb1/examples/auto/fraggles/Red.java
@@ -7,5 +7,7 @@ import com.github.peckb1.processor.Named;
 
 @AutoJackson
 public interface Red extends Fraggle<KarenPrell> {
+
     @Named("dives") int getDives();
+
 }

--- a/examples/src/main/java/com/github/peckb1/examples/auto/fraggles/Wembley.java
+++ b/examples/src/main/java/com/github/peckb1/examples/auto/fraggles/Wembley.java
@@ -1,11 +1,12 @@
 package com.github.peckb1.examples.auto.fraggles;
 
 import com.github.peckb1.examples.auto.Fraggle;
+import com.github.peckb1.examples.auto.muppeteers.SteveWhitmire;
 import com.github.peckb1.processor.AutoJackson;
 import com.github.peckb1.processor.Named;
 
 @AutoJackson
-public interface Wembley extends Fraggle {
+public interface Wembley extends Fraggle<SteveWhitmire> {
 
     @Named("fires") int getNumberOfFiresPutOut();
 

--- a/examples/src/main/java/com/github/peckb1/examples/auto/muppeteers/DaveGoelz.java
+++ b/examples/src/main/java/com/github/peckb1/examples/auto/muppeteers/DaveGoelz.java
@@ -1,0 +1,7 @@
+package com.github.peckb1.examples.auto.muppeteers;
+
+import com.github.peckb1.examples.auto.Muppeteer;
+import com.github.peckb1.processor.AutoJackson;
+
+@AutoJackson
+public interface DaveGoelz extends Muppeteer { }

--- a/examples/src/main/java/com/github/peckb1/examples/auto/muppeteers/JerryNelson.java
+++ b/examples/src/main/java/com/github/peckb1/examples/auto/muppeteers/JerryNelson.java
@@ -1,0 +1,7 @@
+package com.github.peckb1.examples.auto.muppeteers;
+
+import com.github.peckb1.examples.auto.Muppeteer;
+import com.github.peckb1.processor.AutoJackson;
+
+@AutoJackson
+public interface JerryNelson extends Muppeteer { }

--- a/examples/src/main/java/com/github/peckb1/examples/auto/muppeteers/KarenPrell.java
+++ b/examples/src/main/java/com/github/peckb1/examples/auto/muppeteers/KarenPrell.java
@@ -1,0 +1,7 @@
+package com.github.peckb1.examples.auto.muppeteers;
+
+import com.github.peckb1.examples.auto.Muppeteer;
+import com.github.peckb1.processor.AutoJackson;
+
+@AutoJackson
+public interface KarenPrell extends Muppeteer { }

--- a/examples/src/main/java/com/github/peckb1/examples/auto/muppeteers/KathrynMullen.java
+++ b/examples/src/main/java/com/github/peckb1/examples/auto/muppeteers/KathrynMullen.java
@@ -1,0 +1,7 @@
+package com.github.peckb1.examples.auto.muppeteers;
+
+import com.github.peckb1.examples.auto.Muppeteer;
+import com.github.peckb1.processor.AutoJackson;
+
+@AutoJackson
+public interface KathrynMullen extends Muppeteer { }

--- a/examples/src/main/java/com/github/peckb1/examples/auto/muppeteers/SteveWhitmire.java
+++ b/examples/src/main/java/com/github/peckb1/examples/auto/muppeteers/SteveWhitmire.java
@@ -1,0 +1,7 @@
+package com.github.peckb1.examples.auto.muppeteers;
+
+import com.github.peckb1.examples.auto.Muppeteer;
+import com.github.peckb1.processor.AutoJackson;
+
+@AutoJackson
+public interface SteveWhitmire extends Muppeteer { }

--- a/examples/src/test/java/com/github/peckb1/examples/auto/TestModel.java
+++ b/examples/src/test/java/com/github/peckb1/examples/auto/TestModel.java
@@ -7,6 +7,10 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.peckb1.examples.auto.fraggles.Boober;
 import com.github.peckb1.examples.auto.fraggles.Gobo;
 import com.github.peckb1.examples.auto.fraggles.Mokey;
+import com.github.peckb1.examples.auto.muppeteers.DaveGoelz;
+import com.github.peckb1.examples.auto.muppeteers.JerryNelson;
+import com.github.peckb1.examples.auto.muppeteers.KathrynMullen;
+import com.github.peckb1.examples.auto.muppeteers.SteveWhitmire;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -19,13 +23,14 @@ import java.io.IOException;
 import java.sql.Date;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class TestSimpleModel {
+public class TestModel {
 
     private ObjectMapper objectMapper;
 
@@ -51,7 +56,7 @@ public class TestSimpleModel {
         checkSample(sampleAgain);
     }
 
-    private void checkSample(Sample sample) {
+    private void checkSample(Sample sample) throws IOException {
         assertEquals("A String", sample.getString());
         assertEquals(1, sample.getInt());
         assertEquals(true, sample.getBoolean());
@@ -118,7 +123,10 @@ public class TestSimpleModel {
         assertEquals(FraggleName.BOOBER, fraggle.getName());
         assertEquals(11, (int) fraggle.getAge());
         assertEquals("clothes washer", fraggle.getJob());
-        Assert.assertEquals(9001, ((Boober) fraggle).getNumberOfSuperstitions());
+        Muppeteer muppeteer = fraggle.getMuppeteer();
+        assertTrue(muppeteer instanceof DaveGoelz);
+        assertEquals("Dave Goelz", muppeteer.getName());
+        assertEquals(9001, ((Boober) fraggle).getNumberOfSuperstitions());
         assertFalse(fraggle.getRoommate().isPresent());
     }
 
@@ -126,15 +134,25 @@ public class TestSimpleModel {
         assertEquals(FraggleName.MOKEY, fraggle.getName());
         assertEquals(11, (int) fraggle.getAge());
         assertEquals("radish picker", fraggle.getJob());
-        Assert.assertEquals(500, ((Mokey) fraggle).getRadishesPicked());
+        assertEquals(500, ((Mokey) fraggle).getRadishesPicked());
         assertFalse(fraggle.getRoommate().isPresent());
+        Muppeteer muppeteer = fraggle.getMuppeteer();
+        assertFalse(muppeteer instanceof KathrynMullen);
+        assertEquals("Kathryn Mullen", muppeteer.getName());
     }
 
-    private void checkGobo(Fraggle fraggle) {
+    private void checkGobo(Fraggle fraggle) throws IOException {
         assertEquals(FraggleName.GOBO, fraggle.getName());
         assertEquals(10, (int) fraggle.getAge());
         assertEquals("singer", fraggle.getJob());
-        Assert.assertEquals(20, ((Gobo) fraggle).getFetchedPostcards());
+        Muppeteer muppeteer = fraggle.getMuppeteer();
+        assertTrue(muppeteer instanceof JerryNelson);
+        assertEquals("Jerry Nelson", muppeteer.getName());
+        assertEquals(20, ((Gobo) fraggle).getFetchedPostcards());
+        Map map = ((Gobo) fraggle).getMap();
+        assertEquals(1, map.size());
+        assertEquals(4, ((Gobo) fraggle).getX());
+        assertEquals(123, map.get("abc"));
 
         Optional<Fraggle> roommate = fraggle.getRoommate();
         assertTrue(roommate.isPresent());
@@ -145,6 +163,9 @@ public class TestSimpleModel {
         assertEquals(FraggleName.WEMBLEY, fraggle.getName());
         assertEquals(9, (int) fraggle.getAge());
         assertEquals("fire truck siren", fraggle.getJob());
+        Muppeteer muppeteer = fraggle.getMuppeteer();
+        assertTrue(muppeteer instanceof SteveWhitmire);
+        assertEquals("Steve Whitmire", muppeteer.getName());
         assertEquals(15, ((Wembley) fraggle).getNumberOfFiresPutOut());
         assertFalse(fraggle.getRoommate().isPresent());
     }

--- a/examples/src/test/java/com/github/peckb1/examples/auto/TestSimpleModel.java
+++ b/examples/src/test/java/com/github/peckb1/examples/auto/TestSimpleModel.java
@@ -40,7 +40,7 @@ public class TestSimpleModel {
 
     @Test
     public void testSimpleModel() throws IOException {
-        File simpleModelFile = new File("resources/auto_model_simple.json");
+        File simpleModelFile = new File("resources/auto_model.json");
         Sample sample = this.objectMapper.readValue(simpleModelFile, Sample.class);
 
         checkSample(sample);

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.peckb1</groupId>
     <artifactId>autojackson</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>com.github.peckb1</groupId>
         <artifactId>autojackson</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>autojackson-processor</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <properties>
         <auto-service-version>1.0-rc3</auto-service-version>

--- a/processor/src/main/java/com/github/peckb1/processor/util/DeserializerCreator.java
+++ b/processor/src/main/java/com/github/peckb1/processor/util/DeserializerCreator.java
@@ -68,9 +68,12 @@ public abstract class DeserializerCreator {
         ParameterizedTypeName parameterizedDeserializer = ParameterizedTypeName.get(stdDeserializer, deserializerType);
 
         MethodSpec.Builder constructorBuilder = MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC);
+        // since Generics don't work when calling .class, check if there are type parameters
         if (typeElement.getTypeParameters().isEmpty()) {
+            // if not we can use $T
             constructorBuilder.addStatement("super($T.class)", typeElement);
         } else {
+            // if so, we need to use the fully qualified name and $L
             constructorBuilder.addStatement("super($L.class)", typeElement.getQualifiedName());
         }
         MethodSpec constructor = constructorBuilder.build();

--- a/processor/src/main/java/com/github/peckb1/processor/util/DeserializerCreator.java
+++ b/processor/src/main/java/com/github/peckb1/processor/util/DeserializerCreator.java
@@ -19,10 +19,12 @@ import javax.lang.model.element.Modifier;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import java.io.IOException;
+import java.util.List;
 
 /**
  * The parent class for creating the custom deserializer objects
@@ -65,10 +67,13 @@ public abstract class DeserializerCreator {
         TypeName deserializerType = TypeName.get(declaredType);
         ParameterizedTypeName parameterizedDeserializer = ParameterizedTypeName.get(stdDeserializer, deserializerType);
 
-        MethodSpec constructor = MethodSpec.constructorBuilder()
-                .addModifiers(Modifier.PUBLIC)
-                .addStatement("super($T.class)", typeElement)
-                .build();
+        MethodSpec.Builder constructorBuilder = MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC);
+        if (typeElement.getTypeParameters().isEmpty()) {
+            constructorBuilder.addStatement("super($T.class)", typeElement);
+        } else {
+            constructorBuilder.addStatement("super($L.class)", typeElement.getQualifiedName());
+        }
+        MethodSpec constructor = constructorBuilder.build();
 
         ParameterSpec jsonParserParameter = ParameterSpec.builder(JsonParser.class, JSON_PARSER_PARAMETER_NAME)
                 .build();

--- a/processor/src/main/java/com/github/peckb1/processor/util/MethodDetail.java
+++ b/processor/src/main/java/com/github/peckb1/processor/util/MethodDetail.java
@@ -1,0 +1,33 @@
+package com.github.peckb1.processor.util;
+
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.type.TypeMirror;
+import java.util.Optional;
+
+public class MethodDetail implements Comparable<MethodDetail> {
+
+    private final ExecutableElement element;
+    private final Optional<TypeMirror> differentReturnType;
+
+    MethodDetail(ExecutableElement element) {
+        this(element, Optional.empty());
+    }
+
+    MethodDetail(ExecutableElement element, Optional<TypeMirror> differentReturnType) {
+        this.element = element;
+        this.differentReturnType = differentReturnType;
+    }
+
+    public ExecutableElement getElement() {
+        return element;
+    }
+
+    public Optional<TypeMirror> getDifferentReturnType() {
+        return differentReturnType;
+    }
+
+    @Override
+    public int compareTo(MethodDetail o) {
+        return this.element.getSimpleName().toString().compareTo(o.element.getSimpleName().toString());
+    }
+}

--- a/processor/src/main/java/com/github/peckb1/processor/util/MethodDetail.java
+++ b/processor/src/main/java/com/github/peckb1/processor/util/MethodDetail.java
@@ -4,6 +4,12 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.TypeMirror;
 import java.util.Optional;
 
+/**
+ * A wrapper object which contains the standard {@link ExecutableElement} which defines
+ * a method during annotation processing, as well as an optional return type should the
+ * {@link TypeMirror} object inside the base method be a generic variable, rather than
+ * a concrete class that can be instantiated.
+ */
 public class MethodDetail implements Comparable<MethodDetail> {
 
     private final ExecutableElement element;
@@ -18,11 +24,11 @@ public class MethodDetail implements Comparable<MethodDetail> {
         this.differentReturnType = differentReturnType;
     }
 
-    public ExecutableElement getElement() {
+    ExecutableElement getElement() {
         return element;
     }
 
-    public Optional<TypeMirror> getDifferentReturnType() {
+    Optional<TypeMirror> getDifferentReturnType() {
         return differentReturnType;
     }
 

--- a/processor/src/main/java/com/github/peckb1/processor/util/SetupCreator.java
+++ b/processor/src/main/java/com/github/peckb1/processor/util/SetupCreator.java
@@ -15,7 +15,9 @@ import com.squareup.javapoet.TypeSpec;
 import javax.annotation.processing.Filer;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.TypeParameterElement;
 import java.io.IOException;
+import java.util.List;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 import static com.fasterxml.jackson.annotation.PropertyAccessor.ALL;
@@ -55,7 +57,11 @@ public class SetupCreator {
         interfaces.forEach(element -> {
             String deserializationPackage = ClassName.get(element).packageName();
             ClassName deserializerClassName = ClassName.get(deserializationPackage, element.getSimpleName() + DESERIALIZER_CLASS_NAME_SUFFIX);
-            configurationMethodBuilder.addStatement("deserialzationModule.addDeserializer($T.class, new $T())", element, deserializerClassName);
+            if (element.getTypeParameters().isEmpty()) {
+                configurationMethodBuilder.addStatement("deserialzationModule.addDeserializer($T.class, new $T())", element, deserializerClassName);
+            } else {
+                configurationMethodBuilder.addStatement("deserialzationModule.addDeserializer($L.class, new $T())", element.getQualifiedName(), deserializerClassName);
+            }
         });
 
         configurationMethodBuilder


### PR DESCRIPTION
Adjust ImplementationCreator for generics  …
Previously generics fail, as we do not look for the actual type of the
Generic.
see #20
This adds:
  * Type checks when needing to `X.class` since `X<Generic>.class` would fail
  * Type checks the return type of the accessors in case the classes are geneerified