### PR TITLE
Default to not fail on unknown properties

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>com.github.peckb1</groupId>
         <artifactId>autojackson</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>autojackson-examples</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
 
     <build>
         <plugins>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.github.peckb1</groupId>
             <artifactId>autojackson-processor</artifactId>
-            <version>1.1.0</version>
+            <version>1.1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/examples/resources/auto_model.json
+++ b/examples/resources/auto_model.json
@@ -15,7 +15,8 @@
       "fires" : 15,
       "muppeteer" : {
         "name" : "Steve Whitmire"
-      }
+      },
+      "cookies" : true
     },
     "muppeteer" : {
       "name" : "Jerry Nelson"

--- a/examples/src/test/java/com/github/peckb1/examples/auto/TestModel.java
+++ b/examples/src/test/java/com/github/peckb1/examples/auto/TestModel.java
@@ -1,5 +1,6 @@
 package com.github.peckb1.examples.auto;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
@@ -41,6 +42,7 @@ public class TestModel {
         this.objectMapper.registerModule(new Jdk8Module());
         this.objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         AutoJacksonSetup.configureObjectMapper(this.objectMapper);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.peckb1</groupId>
     <artifactId>autojackson</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <properties>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>com.github.peckb1</groupId>
         <artifactId>autojackson</artifactId>
-        <version>1.1.0</version>
+        <version>1.1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>autojackson-processor</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
 
     <properties>
         <auto-service-version>1.0-rc3</auto-service-version>

--- a/processor/src/main/java/com/github/peckb1/processor/util/SetupCreator.java
+++ b/processor/src/main/java/com/github/peckb1/processor/util/SetupCreator.java
@@ -2,6 +2,7 @@ package com.github.peckb1.processor.util;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.github.peckb1.processor.AutoJackson;
@@ -21,6 +22,7 @@ import java.util.List;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.NONE;
 import static com.fasterxml.jackson.annotation.PropertyAccessor.ALL;
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static com.github.peckb1.processor.util.DeserializerCreator.DESERIALIZER_CLASS_NAME_SUFFIX;
 
 /**
@@ -67,6 +69,7 @@ public class SetupCreator {
         configurationMethodBuilder
                 .addStatement("objectMapper.registerModule(deserialzationModule)")
                 .addStatement("objectMapper.setVisibility($T.$L, $T.$L)", PropertyAccessor.class, ALL, Visibility.class, NONE)
+                .addStatement("objectMapper.configure($T.$L, $L)", DeserializationFeature.class, FAIL_ON_UNKNOWN_PROPERTIES, false)
                 .build();
 
         TypeSpec setupClass = TypeSpec


### PR DESCRIPTION
Rather than allow the fail on unknown properties to remain defaulted to true,
the AutoJacksonSetup now has:
```
objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
```
set by default.

Also upgrades us to 1.1.1-SNAPSHOT with the new changes.